### PR TITLE
Fix: Implement reranker batching and correct vector store path logic

### DIFF
--- a/core/retrieval_service.py
+++ b/core/retrieval_service.py
@@ -188,7 +188,16 @@ class RetrievalService:
             # Keep track of original full data to re-associate
             original_items_before_rerank = list(scored_results) # shallow copy
             try:
-                reranked_outputs = self.reranker_service.rerank(query=query_text, documents=parents_for_reranking, top_n=final_top_n) # Reranker handles top_n
+                # Add batch_size argument. Using a default of 4 for now.
+                # This could be made configurable via settings and pipeline parameters later if needed.
+                RERANKER_BATCH_SIZE = 4
+                logger.debug(f"Calling reranker service with batch_size = {RERANKER_BATCH_SIZE}")
+                reranked_outputs = self.reranker_service.rerank(
+                    query=query_text,
+                    documents=parents_for_reranking,
+                    top_n=final_top_n, # Reranker's top_n is applied after batch processing
+                    batch_size=RERANKER_BATCH_SIZE
+                )
 
                 temp_reranked_list = []
                 for reranked_item_from_service in reranked_outputs:


### PR DESCRIPTION
- Implement batching in RerankerService to prevent OOM errors when reranking a large number of documents. RetrievalService now calls the reranker with a default batch size.
- Correct the logic in ReportGenerationPipeline for loading and saving the vector store. Ensures consistent index naming (using provided index_name or deriving from data_path) for both load and save operations, and creates the vector store directory if it doesn't exist. This fixes an issue where indexes might not be found or saved to the intended location if an index_name was not explicitly provided.