### PR TITLE
Fix: Correct vector store path handling and improve workflow logs

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -155,11 +155,21 @@ class Orchestrator:
                 self._execute_task_type(task) # This will call agent's execute_task
 
             iteration_count += 1
-            self.workflow_state.log_event(f"Orchestrator: Workflow iteration {iteration_count} complete.")
+
+            # Log chapter completion progress
+            num_total_chapters = len(self.workflow_state.parsed_outline)
+            num_completed_chapters = self.workflow_state.count_completed_chapters()
+            progress_log_msg = (f"Orchestrator: Workflow iteration {iteration_count} complete. "
+                                f"Chapters: {num_completed_chapters}/{num_total_chapters} completed.")
+            logger.debug(progress_log_msg) # More frequent, so debug level
+            if iteration_count % 5 == 0 or num_total_chapters == num_completed_chapters : # Log to workflow state less frequently
+                self.workflow_state.log_event(progress_log_msg)
+
 
         self.workflow_state.log_event("Orchestrator finished workflow coordination.",
                                      {"total_iterations": iteration_count,
-                                      "final_status_complete": self.workflow_state.get_flag('report_generation_complete')})
+                                      "final_status_complete": self.workflow_state.get_flag('report_generation_complete'),
+                                      "chapters_completed_at_end": f"{self.workflow_state.count_completed_chapters()}/{len(self.workflow_state.parsed_outline)}"})
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)d] - %(message)s')

--- a/core/workflow_state.py
+++ b/core/workflow_state.py
@@ -240,6 +240,18 @@ class WorkflowState:
                 return False
         return True
 
+    def count_completed_chapters(self) -> int:
+        """Counts how many chapters (from parsed_outline) are marked as COMPLETED."""
+        if not self.parsed_outline:
+            return 0
+        count = 0
+        for item in self.parsed_outline:
+            chapter_key = item['id']
+            chapter_info = self.chapter_data.get(chapter_key)
+            if chapter_info and chapter_info.get('status') == STATUS_COMPLETED:
+                count += 1
+        return count
+
     def increment_error_count(self):
         self.error_count += 1
         self.log_event("Global error count incremented.", {"current_error_count": self.error_count})

--- a/main.py
+++ b/main.py
@@ -263,7 +263,10 @@ def main():
             hybrid_alpha=args.hybrid_search_alpha,
             final_top_n_retrieval=args.final_top_n_retrieval,
             max_refinement_iterations=args.max_refinement_iterations,
-            max_workflow_iterations=args.max_workflow_iterations # Pass new CLI arg
+            max_workflow_iterations=args.max_workflow_iterations,
+            vector_store_path=args.vector_store_path,
+            index_name=args.index_name,
+            force_reindex=args.force_reindex
         )
     except Exception as e:
         logger.error(f"Failed to initialize the report generation pipeline: {e}", exc_info=True)

--- a/pipelines/report_generation_pipeline.py
+++ b/pipelines/report_generation_pipeline.py
@@ -132,6 +132,10 @@ class ReportGenerationPipeline:
 
 
     def _process_and_load_data(self, data_path: str):
+        logger.debug(f"Starting _process_and_load_data: initial data_path='{data_path}', "
+                     f"initial self.vector_store_path='{self.vector_store_path}', "
+                     f"initial self.index_name='{self.index_name}', "
+                     f"initial self.force_reindex={self.force_reindex}")
         self.workflow_state.log_event(f"Data processing: data_path='{data_path}', vs_path='{self.vector_store_path}', "
                                      f"index_name='{self.index_name}', force_reindex={self.force_reindex}")
         loaded_from_file = False
@@ -147,10 +151,13 @@ class ReportGenerationPipeline:
                 effective_index_name = "default_rag_index"
             if not effective_index_name: # Further fallback if basename was empty (e.g. data_path was '/')
                 effective_index_name = "default_rag_index"
+
+        logger.debug(f"Determined effective_index_name: '{effective_index_name}'")
         self.workflow_state.log_event(f"Effective index name for VectorStore: '{effective_index_name}'")
 
         # Prepare vector store directory and paths
         vs_dir = os.path.abspath(self.vector_store_path)
+        logger.debug(f"Absolute vector store directory (vs_dir): '{vs_dir}'")
         if not os.path.exists(vs_dir):
             try:
                 os.makedirs(vs_dir, exist_ok=True)
@@ -162,10 +169,13 @@ class ReportGenerationPipeline:
 
         faiss_index_path = os.path.join(vs_dir, f"{effective_index_name}.faiss")
         metadata_path = os.path.join(vs_dir, f"{effective_index_name}.meta.json")
+        logger.debug(f"Calculated FAISS index path: '{faiss_index_path}'")
+        logger.debug(f"Calculated metadata path: '{metadata_path}'")
 
         if not self.force_reindex:
             if os.path.exists(faiss_index_path) and os.path.exists(metadata_path):
                 try:
+                    logger.info(f"Attempting to load existing VectorStore: index='{faiss_index_path}', meta='{metadata_path}'")
                     self.workflow_state.log_event(f"Attempting to load existing VectorStore: index='{faiss_index_path}', meta='{metadata_path}'")
                     self.vector_store.load_store(faiss_index_path, metadata_path)
                     if self.vector_store.count_child_chunks > 0:


### PR DESCRIPTION
- Fixed an issue where CLI arguments for `vector_store_path` and `index_name` were not correctly passed to the ReportGenerationPipeline, causing them to be ignored. These arguments are now explicitly passed in `main.py`.
- Added verbose debug logging in the pipeline's `_process_and_load_data` method to trace the received and calculated vector store paths and index names.
- Added logging in the Orchestrator to report the number of completed chapters at each iteration (to debug log) and every 5 iterations (to workflow state log). This helps diagnose if hitting `max_workflow_iterations` is due to a stall or normal processing of a large report.
- Added `count_completed_chapters` method to WorkflowState.