### PR TITLE
Feat: Integrate json-repair for robust JSON parsing and centralize agent prompts

### DIFF
--- a/agents/chapter_writer_agent.py
+++ b/agents/chapter_writer_agent.py
@@ -18,23 +18,12 @@ class ChapterWriterAgent(BaseAgent):
     Updates WorkflowState with the written content and queues evaluation task.
     """
 
-    DEFAULT_PROMPT_TEMPLATE = """你是一位专业的报告撰写员。请根据以下报告章节标题和相关的参考资料（这些是与章节最相关的父文本块），撰写详细、流畅、专业、连贯的中文章节内容。
-
-章节标题：
-{chapter_title}
-
-参考资料（请基于这些资料进行撰写，不要杜撰）：
-{retrieved_content_formatted}
-
-请确保内容与章节标题紧密相关，并充分、合理地利用提供的参考资料。避免直接复制粘贴参考资料，而是要理解、整合信息，并用自己的话语有条理地表达出来。
-输出的章节内容应具有良好的可读性和专业性。
-
-撰写的章节内容（纯文本，不需要包含章节标题本身）：
-"""
+    # DEFAULT_PROMPT_TEMPLATE will be removed and sourced from settings
 
     def __init__(self, llm_service: LLMService, prompt_template: Optional[str] = None):
         super().__init__(agent_name="ChapterWriterAgent", llm_service=llm_service)
-        self.prompt_template = prompt_template or self.DEFAULT_PROMPT_TEMPLATE
+        from config import settings as app_settings
+        self.prompt_template = prompt_template or app_settings.DEFAULT_CHAPTER_WRITER_PROMPT
         if not self.llm_service:
             raise ChapterWriterAgentError("LLMService is required for ChapterWriterAgent.")
 

--- a/agents/evaluator_agent.py
+++ b/agents/evaluator_agent.py
@@ -1,5 +1,6 @@
 import logging
-import json
+import json # Keep for other JSON operations if any, or remove if only repair is used for loading
+import json_repair # Added
 from typing import Dict, Optional
 
 from agents.base_agent import BaseAgent
@@ -20,43 +21,16 @@ class EvaluatorAgent(BaseAgent):
     then queues the next task (refinement or marks chapter as complete).
     """
 
-    DEFAULT_PROMPT_TEMPLATE = """
-你是一位资深的报告评审员。请根据以下标准评估提供的报告内容：
-1.  **相关性**：内容是否紧扣主题和章节要求？信息是否与讨论的核心问题直接相关？
-2.  **流畅性**：语句是否通顺自然？段落之间过渡是否平滑？逻辑是否清晰？
-3.  **完整性**：信息是否全面？论点是否得到了充分的论证和支持？是否涵盖了应有的关键点？
-4.  **准确性**：所陈述的事实、数据和信息是否准确无误？（请基于常识或普遍接受的知识进行判断，除非提供了特定领域的参考标准）
-
-章节标题： {chapter_title}
-
-待评估内容：
----
-{content_to_evaluate}
----
-
-请对以上内容进行综合评估，并严格按照以下JSON格式返回你的评分和反馈意见。不要添加任何额外的解释或说明文字。
-总评分范围为0-100分。反馈意见应具体指出优点和需要改进的地方。
-
-JSON输出格式：
-{{
-  "score": <总评分，整数>,
-  "feedback_cn": "具体的中文反馈意见，包括优点和改进建议。",
-  "evaluation_criteria_met": {{
-    "relevance": "<关于相关性的简短评价，例如：高/中/低，具体说明>",
-    "fluency": "<关于流畅性的简短评价，例如：优秀/良好/一般/较差，具体说明>",
-    "completeness": "<关于完整性的简短评价，例如：非常全面/基本全面/部分缺失/严重缺失，具体说明>",
-    "accuracy": "<关于准确性的简短评价（基于常识），例如：高/待核实/部分存疑/低，具体说明>"
-    }}
-}}
-"""
+    # DEFAULT_PROMPT_TEMPLATE will be removed and sourced from settings
     # REFINEMENT_SCORE_THRESHOLD will now be taken from settings
 
     def __init__(self,
                  llm_service: LLMService,
                  prompt_template: Optional[str] = None):
         super().__init__(agent_name="EvaluatorAgent", llm_service=llm_service)
-        self.prompt_template = prompt_template or self.DEFAULT_PROMPT_TEMPLATE
-        # refinement_threshold is now read from settings within execute_task or globally
+        from config import settings as app_settings
+        self.prompt_template = prompt_template or app_settings.DEFAULT_EVALUATOR_PROMPT
+        # refinement_threshold is read from settings within execute_task
         if not self.llm_service:
             raise EvaluatorAgentError("LLMService is required for EvaluatorAgent.")
 
@@ -111,11 +85,13 @@ JSON输出格式：
                     json_end_index = raw_response.rfind('}') + 1
                     if json_start_index != -1 and json_end_index != -1 and json_start_index < json_end_index:
                         json_string = raw_response[json_start_index:json_end_index]
-                        evaluation_result = json.loads(json_string)
+                        evaluation_result = json_repair.loads(json_string)
                     else:
-                        raise EvaluatorAgentError(f"LLM eval response no valid JSON: {raw_response}")
-                except json.JSONDecodeError as e:
-                    raise EvaluatorAgentError(f"LLM eval response not valid JSON: {raw_response}. Error: {e}")
+                        # If no clear JSON structure is found, try to repair the whole raw_response
+                        logger.warning(f"No clear JSON object found in LLM eval response, attempting to repair entire response: {raw_response}")
+                        evaluation_result = json_repair.loads(raw_response)
+                except (json.JSONDecodeError, ValueError) as e: # json_repair can also raise ValueError
+                    raise EvaluatorAgentError(f"LLM eval response not valid or repairable JSON: {raw_response}. Error: {e}")
 
                 required_keys = ["score", "feedback_cn", "evaluation_criteria_met"]
                 if not all(key in evaluation_result for key in required_keys):

--- a/agents/outline_generator_agent.py
+++ b/agents/outline_generator_agent.py
@@ -23,31 +23,12 @@ class OutlineGeneratorAgent(BaseAgent):
     and adds tasks to process each chapter.
     """
 
-    DEFAULT_PROMPT_TEMPLATE = """你是一个报告大纲撰写助手。请根据以下主题和关键词，生成一份详细的中文报告大纲。
-大纲应包含主要章节和子章节（如果适用）。请确保大纲结构清晰、逻辑连贯，并覆盖主题的核心方面。
-
-主题：
-{topic_cn} (英文参考: {topic_en})
-
-关键词：
-中文: {keywords_cn}
-英文: {keywords_en}
-
-请以Markdown列表格式返回大纲。例如：
-- 章节一：介绍
-  - 1.1 背景
-  - 1.2 研究意义
-- 章节二：主要发现
-  - 2.1 发现点A
-  - 2.2 发现点B
-- 章节三：结论
-
-输出的大纲内容：
-"""
+    # DEFAULT_PROMPT_TEMPLATE will be removed and sourced from settings
 
     def __init__(self, llm_service: LLMService, prompt_template: Optional[str] = None):
         super().__init__(agent_name="OutlineGeneratorAgent", llm_service=llm_service)
-        self.prompt_template = prompt_template or self.DEFAULT_PROMPT_TEMPLATE
+        from config import settings as app_settings
+        self.prompt_template = prompt_template or app_settings.DEFAULT_OUTLINE_GENERATOR_PROMPT
         if not self.llm_service:
             raise OutlineGeneratorAgentError("LLMService is required for OutlineGeneratorAgent.")
         # For parsing the generated Markdown outline into a structured list with IDs

--- a/agents/refiner_agent.py
+++ b/agents/refiner_agent.py
@@ -18,31 +18,12 @@ class RefinerAgent(BaseAgent):
     evaluation feedback. Updates WorkflowState and queues re-evaluation.
     """
 
-    DEFAULT_PROMPT_TEMPLATE = """你是一位报告修改专家。请根据以下原始内容和评审反馈，对内容进行修改和完善，输出修改后的中文版本。
-你的目标是解决反馈中指出的问题，并提升内容的整体质量，包括相关性、流畅性、完整性和准确性。
-
-章节标题：{chapter_title}
-
-原始内容：
----
-{original_content}
----
-
-评审反馈：
----
-{evaluation_feedback}
----
-
-请仔细阅读评审反馈，理解需要改进的关键点。
-在修改时，请尽量保留原始内容的合理部分，重点针对反馈中提出的不足之处进行优化。
-如果反馈中包含具体的修改建议，请优先考虑采纳。
-
-修改后的内容（纯文本）：
-"""
+    # DEFAULT_PROMPT_TEMPLATE will be removed and sourced from settings
 
     def __init__(self, llm_service: LLMService, prompt_template: Optional[str] = None):
         super().__init__(agent_name="RefinerAgent", llm_service=llm_service)
-        self.prompt_template = prompt_template or self.DEFAULT_PROMPT_TEMPLATE
+        from config import settings as app_settings
+        self.prompt_template = prompt_template or app_settings.DEFAULT_REFINER_PROMPT
         if not self.llm_service:
             raise RefinerAgentError("LLMService is required for RefinerAgent.")
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -25,8 +25,8 @@ DEFAULT_EMBEDDING_MODEL_NAME = os.getenv("DEFAULT_EMBEDDING_MODEL_NAME", "Qwen3-
 # Reranker 模型配置 (Reranker Model Configuration)
 # ==============================================================================
 DEFAULT_RERANKER_MODEL_NAME = os.getenv("DEFAULT_RERANKER_MODEL_NAME", "Qwen3-Reranker-0.6B") # 默认 Reranker 模型名称
-DEFAULT_RERANKER_BATCH_SIZE = int(os.getenv("DEFAULT_RERANKER_BATCH_SIZE", "1")) # Reranker 处理文档时的批次大小
-DEFAULT_RERANKER_MAX_TEXT_LENGTH = int(os.getenv("DEFAULT_RERANKER_MAX_TEXT_LENGTH", "5000")) # 发送给 Reranker 的文档最大字符长度 (超长会截断)
+DEFAULT_RERANKER_BATCH_SIZE = int(os.getenv("DEFAULT_RERANKER_BATCH_SIZE", "2")) # Reranker 处理文档时的批次大小 (调小默认值)
+DEFAULT_RERANKER_MAX_TEXT_LENGTH = int(os.getenv("DEFAULT_RERANKER_MAX_TEXT_LENGTH", "512")) # 发送给 Reranker 的文档最大字符长度 (调小默认值)
 
 # ==============================================================================
 # 文档处理配置 (Document Processing Configuration)
@@ -84,6 +84,113 @@ DEFAULT_EVALUATOR_REFINEMENT_THRESHOLD = int(os.getenv("DEFAULT_EVALUATOR_REFINE
 # ==============================================================================
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper() # 日志级别 (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
+# ==============================================================================
+# Agent 默认 Prompt 模板 (Agent Default Prompt Templates)
+# ==============================================================================
+
+# --- TopicAnalyzerAgent ---
+DEFAULT_TOPIC_ANALYZER_PROMPT = """你是一个主题分析专家。请分析以下用户提供的主题，对其进行理解、扩展和泛化，并生成相关的中文和英文关键词/主题概念，以便于后续的文档检索。请确保关键词的全面性。
+
+用户主题：'{user_topic}'
+
+请严格按照以下JSON格式返回结果，不要添加任何额外的解释或说明文字：
+{{
+  "generalized_topic_cn": "泛化后的中文主题",
+  "generalized_topic_en": "Generalized English Topic",
+  "keywords_cn": ["中文关键词1", "中文关键词2", "中文关键词3"],
+  "keywords_en": ["English Keyword1", "English Keyword2", "English Keyword3"]
+}}
+"""
+
+# --- OutlineGeneratorAgent ---
+DEFAULT_OUTLINE_GENERATOR_PROMPT = """你是一个报告大纲撰写助手。请根据以下主题和关键词，生成一份详细的中文报告大纲。
+大纲应包含主要章节和子章节（如果适用）。请确保大纲结构清晰、逻辑连贯，并覆盖主题的核心方面。
+
+主题：
+{topic_cn} (英文参考: {topic_en})
+
+关键词：
+中文: {keywords_cn}
+英文: {keywords_en}
+
+请以Markdown列表格式返回大纲。例如：
+- 章节一：介绍
+  - 1.1 背景
+  - 1.2 研究意义
+- 章节二：主要发现
+  - 2.1 发现点A
+  - 2.2 发现点B
+- 章节三：结论
+
+输出的大纲内容：
+"""
+
+# --- ChapterWriterAgent ---
+DEFAULT_CHAPTER_WRITER_PROMPT = """你是一位专业的报告撰写员。请根据以下报告章节标题和相关的参考资料（这些是与章节最相关的父文本块），撰写详细、流畅、专业、连贯的中文章节内容。
+
+章节标题：
+{chapter_title}
+
+参考资料（请基于这些资料进行撰写，不要杜撰）：
+{retrieved_content_formatted}
+
+请确保内容与章节标题紧密相关，并充分、合理地利用提供的参考资料。避免直接复制粘贴参考资料，而是要理解、整合信息，并用自己的话语有条理地表达出来。
+输出的章节内容应具有良好的可读性和专业性。
+
+撰写的章节内容（纯文本，不需要包含章节标题本身）：
+"""
+
+# --- EvaluatorAgent ---
+DEFAULT_EVALUATOR_PROMPT = """你是一位资深的报告评审员。请根据以下标准评估提供的报告内容：
+1.  **相关性**：内容是否紧扣主题和章节要求？信息是否与讨论的核心问题直接相关？
+2.  **流畅性**：语句是否通顺自然？段落之间过渡是否平滑？逻辑是否清晰？
+3.  **完整性**：信息是否全面？论点是否得到了充分的论证和支持？是否涵盖了应有的关键点？
+4.  **准确性**：所陈述的事实、数据和信息是否准确无误？（请基于常识或普遍接受的知识进行判断，除非提供了特定领域的参考标准）
+
+章节标题： {chapter_title}
+
+待评估内容：
+---
+{content_to_evaluate}
+---
+
+请对以上内容进行综合评估，并严格按照以下JSON格式返回你的评分和反馈意见。不要添加任何额外的解释或说明文字。
+总评分范围为0-100分。反馈意见应具体指出优点和需要改进的地方。
+
+JSON输出格式：
+{{
+  "score": <总评分，整数>,
+  "feedback_cn": "具体的中文反馈意见，包括优点和改进建议。",
+  "evaluation_criteria_met": {
+    "relevance": "<关于相关性的简短评价，例如：高/中/低，具体说明>",
+    "fluency": "<关于流畅性的简短评价，例如：优秀/良好/一般/较差，具体说明>",
+    "completeness": "<关于完整性的简短评价，例如：非常全面/基本全面/部分缺失/严重缺失，具体说明>",
+    "accuracy": "<关于准确性的简短评价（基于常识），例如：高/待核实/部分存疑/低，具体说明>"
+}}
+"""
+
+# --- RefinerAgent ---
+DEFAULT_REFINER_PROMPT = """你是一位报告修改专家。请根据以下原始内容和评审反馈，对内容进行修改和完善，输出修改后的中文版本。
+你的目标是解决反馈中指出的问题，并提升内容的整体质量，包括相关性、流畅性、完整性和准确性。
+
+章节标题：{chapter_title}
+
+原始内容：
+---
+{original_content}
+---
+
+评审反馈：
+---
+{evaluation_feedback}
+---
+
+请仔细阅读评审反馈，理解需要改进的关键点。
+在修改时，请尽量保留原始内容的合理部分，重点针对反馈中提出的不足之处进行优化。
+如果反馈中包含具体的修改建议，请优先考虑采纳。
+
+修改后的内容（纯文本）：
+"""
 
 # ==============================================================================
 # 使用示例 (Example of how to use these settings)
@@ -140,3 +247,10 @@ if __name__ == '__main__':
 
     print("\n--- 日志配置 ---")
     print(f"LOG_LEVEL: {LOG_LEVEL}")
+
+    print("\n--- Agent 默认 Prompt 模板 ---")
+    print(f"DEFAULT_TOPIC_ANALYZER_PROMPT (first 50 chars): {DEFAULT_TOPIC_ANALYZER_PROMPT[:50]}...")
+    print(f"DEFAULT_OUTLINE_GENERATOR_PROMPT (first 50 chars): {DEFAULT_OUTLINE_GENERATOR_PROMPT[:50]}...")
+    print(f"DEFAULT_CHAPTER_WRITER_PROMPT (first 50 chars): {DEFAULT_CHAPTER_WRITER_PROMPT[:50]}...")
+    print(f"DEFAULT_EVALUATOR_PROMPT (first 50 chars): {DEFAULT_EVALUATOR_PROMPT[:50]}...")
+    print(f"DEFAULT_REFINER_PROMPT (first 50 chars): {DEFAULT_REFINER_PROMPT[:50]}...")

--- a/main.py
+++ b/main.py
@@ -161,7 +161,6 @@ def main():
         "--max_refinement_iterations", type=int, default=settings.DEFAULT_MAX_REFINEMENT_ITERATIONS,
         help="Maximum number of refinement iterations for each chapter."
     )
-
     pipeline_group.add_argument(
         "--max_workflow_iterations", type=int, default=settings.DEFAULT_PIPELINE_MAX_WORKFLOW_ITERATIONS,
         help="Maximum number of iterations for the main workflow loop to prevent infinite loops."

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ nltk>=3.8.0 # For sentence tokenization in parent-child chunking
 # Vector store and numerical operations
 faiss-cpu>=1.7.0 # For local vector similarity search (CPU version)
 numpy>=1.20.0 # Required by FAISS and for numerical operations
+json-repair>=0.14.0 # For repairing potentially malformed JSON from LLMs
 
 # Optional, but good for managing settings via .env files
 # python-dotenv

--- a/run.sh
+++ b/run.sh
@@ -4,5 +4,4 @@ python main.py \
     --output_path "output/ADTC.md" \
     --index_name "abms" \
     --vector_store_path "./my_vector_indexes/" \
-    --log_level DEBUG \
-    --debug
+    --log_level DEBUG


### PR DESCRIPTION
- Added `json-repair` to `requirements.txt`.
- Moved all default agent prompt templates from individual agent files into `config/settings.py` for centralized management and easier modification.
- Updated agent constructors (`TopicAnalyzerAgent`, `OutlineGeneratorAgent`, `ChapterWriterAgent`, `EvaluatorAgent`, `RefinerAgent`) to source their default prompts from these new settings in `config/settings.py`.
- Replaced `json.loads()` with `json_repair.loads()` in `TopicAnalyzerAgent` and `EvaluatorAgent` for parsing LLM responses expected to be JSON. This enhances robustness against malformed JSON outputs from language models.
- Improved error handling around JSON parsing in these agents, including a fallback to attempt repair on the entire raw response if a clear JSON substring is not initially identified.