### PR TITLE
Fix: Correct variable name in retrieval and log_event call in agent

### DIFF
--- a/agents/content_retriever_agent.py
+++ b/agents/content_retriever_agent.py
@@ -143,7 +143,7 @@ class ContentRetrieverAgent(BaseAgent):
             raise ContentRetrieverAgentError(err_msg) # Re-raise
         except Exception as e:
             err_msg = f"Unexpected error during content retrieval for '{chapter_title}': {e}"
-            workflow_state.log_event(err_msg, {"error": str(e)}, level="CRITICAL") # Keep this log
+            workflow_state.log_event(err_msg, {"error": str(e)}) # Removed level="CRITICAL"
             workflow_state.add_chapter_error(chapter_key, f"Unexpected error: {e}")
             logger.critical(f"[{self.agent_name}] Task ID: {task_id} - {err_msg}", exc_info=True)
             if task_id: workflow_state.complete_task(task_id, err_msg, status='failed')

--- a/core/retrieval_service.py
+++ b/core/retrieval_service.py
@@ -242,7 +242,7 @@ class RetrievalService:
         # --- 5. Format for Output ---
         # Ensure the output format is suitable for ChapterWriterAgent
         output_for_chapter_writer: List[Dict[str, Any]] = []
-        for res_item in results_after_rerank_or_hybrid:
+        for res_item in results_after_processing: # Corrected variable name
             output_for_chapter_writer.append({
                 "document": res_item["parent_text"], # Key for ChapterWriterAgent
                 "score": res_item["final_score"],


### PR DESCRIPTION
- Corrected a NameError in `core/retrieval_service.py` by changing `results_after_rerank_or_hybrid` to the correct variable `results_after_processing`.
- Fixed a TypeError in `agents/content_retriever_agent.py` by removing the unexpected `level` keyword argument from a `workflow_state.log_event()` call.