### PR TITLE
Update citation sourcing to include original file name and full parag…

### DIFF
--- a/agents/chapter_writer_agent.py
+++ b/agents/chapter_writer_agent.py
@@ -90,7 +90,7 @@ class ChapterWriterAgent(BaseAgent):
 
         citations = []
         for doc in used_documents:
-            file_name = doc.get('source_document_id', '未知文档')
+            file_name = doc.get('source_document_name', '未知文档') # Changed key
             source_text_of_parent = doc.get('document', '无法获取原文') # 'document' holds parent_text
             citations.append(f"[引用来源：{file_name}。原文表述：{source_text_of_parent}]")
 
@@ -252,9 +252,23 @@ if __name__ == '__main__':
     test_chapter_key = "chap_abms_overview"
     test_chapter_title = "ABMS系统概述"
     mock_retrieved_data = [
-        {"document": "父块1：ABMS是一个复杂的系统...", "score": 0.9, "source": "hybrid", "child_text_preview": "子块1预览..."},
-        {"document": "父块2：JADC2与ABMS的关系...", "score": 0.85, "source": "hybrid", "child_text_preview": "子块2预览..."}
+        {
+            "document": "父块1：ABMS是一个复杂的系统...", "score": 0.9, "retrieval_source": "hybrid",
+            "child_text_preview": "子块1预览...", "child_id": "p1c1", "parent_id": "p1",
+            "source_document_name": "source_doc_A.pdf" # Changed key
+        },
+        {
+            "document": "父块2：JADC2与ABMS的关系...", "score": 0.85, "retrieval_source": "hybrid",
+            "child_text_preview": "子块2预览...", "child_id": "p2c1", "parent_id": "p2",
+            "source_document_name": "source_doc_B.txt" # Changed key
+        }
     ]
+
+    # The mock LLM doesn't use citations, so the output won't show them,
+    # but we are testing the logic that _would_ generate them.
+    # To see the generated citations in the test output, we'd have to modify MockLLMService
+    # or inspect the `citations_string` variable directly if we had access.
+    # For now, we confirm the `source_document_name` is correctly accessed.
 
     mock_state_cwa = MockWorkflowStateCWA(user_topic="ABMS",
                                           chapter_key=test_chapter_key,

--- a/core/retrieval_service.py
+++ b/core/retrieval_service.py
@@ -249,7 +249,7 @@ class RetrievalService:
                 "child_text_preview": res_item["child_text"][:150] + "...", # For context/logging
                 "child_id": res_item["child_id"],
                 "parent_id": res_item["parent_id"],
-                "source_document_id": res_item["source_document_id"],
+                "source_document_name": res_item["source_document_name"], # Changed key
                 "retrieval_source": res_item["retrieval_source"] # For tracing
             })
 
@@ -281,7 +281,7 @@ if __name__ == '__main__':
                     self.document_store.append({
                         'child_id': c_data['child_id'], 'child_text': c_data['child_text'],
                         'parent_id': p_data['parent_id'], 'parent_text': p_data['parent_text'],
-                        'source_document_id': p_data['source_document_id']
+                        'source_document_name': p_data['source_document_name'] # Changed key
                     })
             self.count_child_chunks = len(self.document_store)
             logger.debug(f"MockVectorStoreForRS populated with {self.count_child_chunks} items via mock add.")
@@ -317,11 +317,11 @@ if __name__ == '__main__':
 
     # --- Setup Data for Mocks ---
     sample_p_c_data = [
-        {"parent_id": "P1", "parent_text": "Parent One: Apples are red. Oranges are orange.", "source_document_id": "DocA",
+        {"parent_id": "P1", "parent_text": "Parent One: Apples are red. Oranges are orange.", "source_document_name": "DocA.txt", # Changed key
          "children": [{"child_id": "P1C1", "child_text": "Apples are red."}, {"child_id": "P1C2", "child_text": "Oranges are orange."}]},
-        {"parent_id": "P2", "parent_text": "Parent Two: Bananas are yellow. Grapes are purple.", "source_document_id": "DocA",
+        {"parent_id": "P2", "parent_text": "Parent Two: Bananas are yellow. Grapes are purple.", "source_document_name": "DocA.txt", # Changed key
          "children": [{"child_id": "P2C1", "child_text": "Bananas are yellow."}, {"child_id": "P2C2", "child_text": "Grapes are purple."}]},
-        {"parent_id": "P3", "parent_text": "Parent Three: Cars are fast. Bikes are good for exercise.", "source_document_id": "DocB",
+        {"parent_id": "P3", "parent_text": "Parent Three: Cars are fast. Bikes are good for exercise.", "source_document_name": "DocB.pdf", # Changed key
          "children": [{"child_id": "P3C1", "child_text": "Cars are fast and come in red or blue."}, {"child_id": "P3C2", "child_text": "Bikes are good for exercise and fun."}]}
     ]
 

--- a/core/vector_store.py
+++ b/core/vector_store.py
@@ -37,7 +37,7 @@ class VectorStore:
         # self.documents list will now store dictionaries for each child chunk,
         # including its text, its parent's text, and relevant IDs.
         # Format: {'child_id': str, 'child_text': str, 'parent_id': str, 'parent_text': str,
-        #          'source_document_id': str}
+        #          'source_document_name': str} # Changed key name
         # The FAISS index will map to the index of this list.
         self.document_store: List[Dict[str, Any]] = []
 
@@ -67,7 +67,7 @@ class VectorStore:
 
         Args:
             parent_child_data (List[Dict[str, Any]]): A list of parent chunk dictionaries,
-                each containing 'parent_id', 'parent_text', 'source_document_id',
+                each containing 'parent_id', 'parent_text', 'source_document_name', # Changed key name
                 and a 'children' list (List[Dict{'child_id': str, 'child_text': str}]).
                 This structure comes from DocumentProcessor.
 
@@ -86,7 +86,7 @@ class VectorStore:
         for parent_info in parent_child_data:
             parent_id = parent_info['parent_id']
             parent_text = parent_info['parent_text']
-            source_doc_id = parent_info['source_document_id']
+            source_doc_name = parent_info['source_document_name'] # Changed key name
 
             for child_info in parent_info.get('children', []):
                 child_id = child_info['child_id']
@@ -102,7 +102,7 @@ class VectorStore:
                     'child_text': child_text,
                     'parent_id': parent_id,
                     'parent_text': parent_text, # Store parent text for easy retrieval
-                    'source_document_id': source_doc_id
+                    'source_document_name': source_doc_name # Changed key name
                 })
 
         if not child_texts_for_embedding:
@@ -171,7 +171,7 @@ class VectorStore:
                     'child_text': str,
                     'parent_id': str,
                     'parent_text': str,
-                    'source_document_id': str,
+                    'source_document_name': str, # Changed key name
                     'score': float (distance score from FAISS)
                 }
                 Lower scores (distances) mean higher similarity for L2.
@@ -214,7 +214,7 @@ class VectorStore:
                             'child_text': retrieved_item_meta['child_text'],
                             'parent_id': retrieved_item_meta['parent_id'],
                             'parent_text': retrieved_item_meta['parent_text'],
-                            'source_document_id': retrieved_item_meta['source_document_id'],
+                            'source_document_name': retrieved_item_meta['source_document_name'], # Changed key name
                             'score': float(distances[0, i]) # L2 distance
                         }
                         results.append(result_entry)
@@ -329,7 +329,7 @@ if __name__ == '__main__':
     sample_data = [
         {
             "parent_id": "doc1-p1", "parent_text": "Parent One. It talks about apples and oranges. Also mentions bananas.",
-            "source_document_id": "doc1",
+            "source_document_name": "doc1.txt", # Changed key name and made it more file-like
             "children": [
                 {"child_id": "doc1-p1-c1", "child_text": "Parent One. It talks about apples and oranges."},
                 {"child_id": "doc1-p1-c2", "child_text": "Also mentions bananas."}
@@ -337,7 +337,7 @@ if __name__ == '__main__':
         },
         {
             "parent_id": "doc1-p2", "parent_text": "Parent Two. This one is about grapes and strawberries. And kiwi fruit.",
-            "source_document_id": "doc1",
+            "source_document_name": "doc1.txt", # Changed key name
             "children": [
                 {"child_id": "doc1-p2-c1", "child_text": "Parent Two. This one is about grapes and strawberries."},
                 {"child_id": "doc1-p2-c2", "child_text": "And kiwi fruit is tasty."}
@@ -345,7 +345,7 @@ if __name__ == '__main__':
         },
         {
             "parent_id": "doc2-p1", "parent_text": "Another document. Parent Three. Discusses red cars and blue bikes. Fast vehicles.",
-            "source_document_id": "doc2",
+            "source_document_name": "doc2.pdf", # Changed key name
             "children": [
                 {"child_id": "doc2-p1-c1", "child_text": "Another document. Parent Three. Discusses red cars and blue bikes."},
                 {"child_id": "doc2-p1-c2", "child_text": "Fast vehicles are exciting."}


### PR DESCRIPTION
…raph

- Modified DocumentProcessor to store original file name as source_document_name.
- Updated VectorStore and RetrievalService to handle source_document_name.
- Adjusted ChapterWriterAgent to use source_document_name and full parent paragraph in citations.