### PR TITLE
feat: Add pre-outline retrieval to enhance relevance

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -105,8 +105,9 @@ DEFAULT_TOPIC_ANALYZER_PROMPT = """你是一个主题分析专家。请分析以
 """
 
 # --- OutlineGeneratorAgent ---
-DEFAULT_OUTLINE_GENERATOR_PROMPT = """你是一个报告大纲撰写助手。请根据以下主题和关键词，生成一份详细的中文报告大纲。
+DEFAULT_OUTLINE_GENERATOR_PROMPT = """你是一个报告大纲撰写助手。请根据以下主题、关键词以及提供的参考资料，生成一份详细的中文报告大纲。
 大纲应包含主要章节和子章节（如果适用）。请确保大纲结构清晰、逻辑连贯，并覆盖主题的核心方面。
+如果参考资料与主题相关，请尝试在大纲中体现参考资料中的关键信息点，并确保这些章节有据可循。
 
 主题：
 {topic_cn} (英文参考: {topic_en})
@@ -115,13 +116,18 @@ DEFAULT_OUTLINE_GENERATOR_PROMPT = """你是一个报告大纲撰写助手。请
 中文: {keywords_cn}
 英文: {keywords_en}
 
+参考资料：
+---
+{retrieved_context}
+---
+
 请以Markdown列表格式返回大纲。例如：
 - 章节一：介绍
   - 1.1 背景
   - 1.2 研究意义
-- 章节二：主要发现
-  - 2.1 发现点A
-  - 2.2 发现点B
+- 章节二：主要发现 (可能基于参考资料)
+  - 2.1 发现点A (来自资料1)
+  - 2.2 发现点B (来自资料2)
 - 章节三：结论
 
 输出的大纲内容：


### PR DESCRIPTION
Integrates a retrieval step into the OutlineGeneratorAgent before it calls the LLM. This retrieved context is used to inform the initial outline generation, aiming for a more relevant and evidence-backed structure from the start.

Key changes:
- OutlineGeneratorAgent now accepts RetrievalService.
- It performs a retrieval based on topic details (topic, keywords) prior to generating the LLM prompt.
- The retrieved document snippets are formatted and added to the prompt for the LLM.
- The DEFAULT_OUTLINE_GENERATOR_PROMPT in settings.py has been updated to include a placeholder for this retrieved context and instructs the LLM to use it.
- ReportGenerationPipeline has been updated to correctly initialize OutlineGeneratorAgent with the RetrievalService, deferring its instantiation until RetrievalService is available.
- Mock tests in OutlineGeneratorAgent have been updated.

Note: Full end-to-end testing was hindered by sandbox disk space limitations preventing complete dependency installation.