### PR TITLE
I've fixed the anchor links in the generated report. Here's a summary…

### DIFF
--- a/agents/outline_generator_agent.py
+++ b/agents/outline_generator_agent.py
@@ -80,8 +80,10 @@ class OutlineGeneratorAgent(BaseAgent):
                 continue # Skip lines not recognized as outline items
 
             if title:
+                # Use a simpler, index-based ID for consistency, as UUIDs are not used for linking.
+                item_id = f"outline_{len(parsed_items) + 1}"
                 parsed_items.append({
-                    "id": f"ch_{str(uuid.uuid4())[:8]}", # Unique ID for this chapter/section
+                    "id": item_id,
                     "title": title,
                     "level": level
                 })

--- a/agents/report_compiler_agent.py
+++ b/agents/report_compiler_agent.py
@@ -92,8 +92,8 @@ class ReportCompilerAgent(BaseAgent):
         for item in structured_outline: # structured_outline now comes from WorkflowState.parsed_outline
             title = item['title']
             level = item.get('level', 1) # Default to level 1 if not specified
-            # Use the 'id' from parsed_outline for anchor, as it's the unique key
-            anchor = item.get('id', self._generate_anchor(title))
+            # Use the generated anchor from the title for linking.
+            anchor = self._generate_anchor(title)
 
             indent = "  " * (level - 1) if level > 0 else ""
             toc += f"{indent}- [{title}](#{anchor})\n"
@@ -165,7 +165,8 @@ class ReportCompilerAgent(BaseAgent):
                 # Optionally add placeholder: final_report_parts.append(f"\n{'#' * level} {chapter_title_key}\n\n*内容待定*\n")
                 continue
 
-            final_report_parts.append(f"\n<a id=\"{item_id_anchor}\"></a>\n{'#' * level} {chapter_title_key}\n\n{content}\n")
+            # Rely on Markdown renderer to create anchors from headers.
+            final_report_parts.append(f"\n{'#' * level} {chapter_title_key}\n\n{content}\n")
 
         compiled_report = "".join(final_report_parts).strip()
         self._log_output(compiled_report[:500] + "...") # Log preview


### PR DESCRIPTION
… of the changes:

- I replaced the UUID-based anchors with title-based ones.
- This ensures that the table of contents links work correctly in standard Markdown viewers.
- I modified `outline_generator_agent.py` to generate simpler, index-based IDs.
- I also modified `report_compiler_agent.py` to generate title-based anchors for the table of contents and remove the manual `<a id...>` tags.