### PR TITLE
Fix: Limit the number of documents sent to the reranker

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -27,6 +27,7 @@ DEFAULT_EMBEDDING_MODEL_NAME = os.getenv("DEFAULT_EMBEDDING_MODEL_NAME", "Qwen3-
 DEFAULT_RERANKER_MODEL_NAME = os.getenv("DEFAULT_RERANKER_MODEL_NAME", "Qwen3-Reranker-0.6B") # 默认 Reranker 模型名称
 DEFAULT_RERANKER_BATCH_SIZE = int(os.getenv("DEFAULT_RERANKER_BATCH_SIZE", "2")) # Reranker 处理文档时的批次大小 (调小默认值)
 DEFAULT_RERANKER_MAX_TEXT_LENGTH = int(os.getenv("DEFAULT_RERANKER_MAX_TEXT_LENGTH", "32000")) # 发送给 Reranker 的文档最大字符长度 (调小默认值)
+DEFAULT_RERANKER_INPUT_LIMIT = int(os.getenv("DEFAULT_RERANKER_INPUT_LIMIT", "100")) # 发送给 Reranker 的最大文档数量
 
 # ==============================================================================
 # 文档处理配置 (Document Processing Configuration)

--- a/core/retrieval_service.py
+++ b/core/retrieval_service.py
@@ -178,6 +178,13 @@ class RetrievalService:
         results_after_processing: List[Dict[str, Any]] = []
 
         if self.reranker_service:
+            # Limit the number of documents sent to the reranker
+            if len(unique_child_chunks_for_reranking) > settings.DEFAULT_RERANKER_INPUT_LIMIT:
+                logger.info(f"Limiting documents for reranker from {len(unique_child_chunks_for_reranking)} to {settings.DEFAULT_RERANKER_INPUT_LIMIT}.")
+                # We don't have a good pre-rerank score, so we just truncate the list.
+                # This is a simple strategy to prevent OOM errors.
+                unique_child_chunks_for_reranking = unique_child_chunks_for_reranking[:settings.DEFAULT_RERANKER_INPUT_LIMIT]
+
             parents_for_reranking = [res['parent_text'] for res in unique_child_chunks_for_reranking]
             # Keep original items to map back after reranking, as reranker works on indices
             original_items_before_rerank = list(unique_child_chunks_for_reranking)


### PR DESCRIPTION
Previously, the retrieval service would send all aggregated and unique documents from multiple queries to the reranker service. This could lead to a very large number of documents, causing out-of-memory (OOM) errors in the reranker.

This change introduces a new configuration, `DEFAULT_RERANKER_INPUT_LIMIT`, which defaults to 100. The retrieval service now truncates the list of documents to this limit before sending them to the reranker.

This prevents the reranker from being overloaded with too many documents, while still providing a sufficiently large pool of candidates for effective reranking.