### PR TITLE
feat: Add option to disable LLM relevance check

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -71,7 +71,10 @@ DEFAULT_KEYWORD_SEARCH_TOP_K = int(os.getenv("DEFAULT_KEYWORD_SEARCH_TOP_K", "20
 DEFAULT_RETRIEVAL_FINAL_TOP_N = int(os.getenv("DEFAULT_RETRIEVAL_FINAL_TOP_N", "40"))
 
 # RERANKER 阈值
-DEFAULT_RETRIEVAL_MIN_SCORE_THRESHOLD = float(os.getenv("DEFAULT_RETRIEVAL_MIN_SCORE_THRESHOLD", "0.4"))
+RERANKER_SCORE_THRESHOLD = float(os.getenv("RERANKER_SCORE_THRESHOLD", "0.4"))
+
+# Chapter Writer Agent Configuration
+USE_LLM_RELEVANCE_CHECK = os.getenv("USE_LLM_RELEVANCE_CHECK", "True").lower() == "true"
 
 # --- Agent Specific Retrieval Settings ---
 # For OutlineGeneratorAgent: Number of documents for initial outline context

--- a/core/retrieval_service.py
+++ b/core/retrieval_service.py
@@ -193,7 +193,7 @@ class RetrievalService:
                 logger.debug(f"Calling reranker service for {len(parents_for_reranking)} documents "
                              f"with representative query: '{representative_query_for_reranking[:100]}...'. "
                              f"Reranker top_n (from final_top_n): {final_top_n}, "
-                             f"Reranker score threshold: {settings.DEFAULT_RETRIEVAL_MIN_SCORE_THRESHOLD}")
+                             f"Reranker score threshold: {settings.RERANKER_SCORE_THRESHOLD}")
 
                 # The reranker service itself will sort by relevance_score and apply its own top_n
                 reranked_outputs = self.reranker_service.rerank(
@@ -211,7 +211,7 @@ class RetrievalService:
 
                     # Apply reranker score threshold
                     reranker_score = reranked_item_from_service['relevance_score']
-                    if reranker_score >= settings.DEFAULT_RETRIEVAL_MIN_SCORE_THRESHOLD:
+                    if reranker_score >= settings.RERANKER_SCORE_THRESHOLD:
                         temp_reranked_list.append({
                             **original_full_data,
                             'final_score': reranker_score, # Use reranker's score as the final score
@@ -219,7 +219,7 @@ class RetrievalService:
                         })
                     else:
                         # logger.debug(f"Document with original index {original_idx} (child_id: {original_full_data.get('child_id')}) "
-                        #              f"discarded due to rerank score {reranker_score:.4f} < threshold {settings.DEFAULT_RETRIEVAL_MIN_SCORE_THRESHOLD}.")
+                        #              f"discarded due to rerank score {reranker_score:.4f} < threshold {settings.RERANKER_SCORE_THRESHOLD}.")
                         # print all documents full text and score, with reranker_score < threshold
                         # logger.info("Discarded documents:\n"+ '-'*50)
                         # logger.info(f"Full text: {original_full_data.get('parent_text', '')}")
@@ -318,7 +318,7 @@ if __name__ == '__main__':
             return np.random.rand(len(self.corpus)) * 10
 
     class MockRerankerServiceForRS:
-        def rerank(self, query: str, documents: List[str], top_n: Optional[int]) -> List[Dict[str, Any]]:
+        def rerank(self, query: str, documents: List[str], top_n: Optional[int], batch_size: int, max_text_length: int) -> List[Dict[str, Any]]:
             logger.debug(f"MockRerankerService.rerank called for '{query}', {len(documents)} docs, top_n={top_n}")
             reranked = []
             for i, doc_text in enumerate(reversed(documents)):

--- a/main.py
+++ b/main.py
@@ -164,6 +164,17 @@ def main():
         "--max_workflow_iterations", type=int, default=50, # Default from old pipeline init
         help="Maximum number of iterations for the main workflow loop to prevent infinite loops."
     )
+    pipeline_group.add_argument(
+        '--no-llm-relevance-check',
+        action='store_true',
+        help="Disable the LLM-based relevance check for retrieved documents."
+    )
+    pipeline_group.add_argument(
+        '--reranker-score-threshold',
+        type=float,
+        default=settings.RERANKER_SCORE_THRESHOLD,
+        help="Minimum score from the reranker for a document to be considered relevant."
+    )
 
     # Vector Store / Indexing arguments
     indexing_group = parser.add_argument_group('Vector Store and Indexing Parameters')
@@ -271,7 +282,18 @@ def main():
             reranker_service=reranker_service,
             vector_store_path=args.vector_store_path,
             index_name=args.index_name,
-            force_reindex=args.force_reindex
+            force_reindex=args.force_reindex,
+            max_workflow_iterations=args.max_workflow_iterations,
+            cli_overridden_parent_chunk_size=args.parent_chunk_size,
+            cli_overridden_parent_chunk_overlap=args.parent_chunk_overlap,
+            cli_overridden_child_chunk_size=args.child_chunk_size,
+            cli_overridden_child_chunk_overlap=args.child_chunk_overlap,
+            cli_overridden_vector_top_k=args.vector_top_k,
+            cli_overridden_keyword_top_k=args.keyword_top_k,
+            cli_overridden_final_top_n_retrieval=args.final_top_n_retrieval,
+            cli_overridden_max_refinement_iterations=args.max_refinement_iterations,
+            use_llm_relevance_check=not args.no_llm_relevance_check,
+            reranker_score_threshold=args.reranker_score_threshold,
         )
     except Exception as e:
         logger.error(f"Failed to initialize the report generation pipeline: {e}", exc_info=True)

--- a/pipelines/report_generation_pipeline.py
+++ b/pipelines/report_generation_pipeline.py
@@ -55,6 +55,8 @@ class ReportGenerationPipeline:
                 #  cli_overridden_hybrid_alpha: float = settings.DEFAULT_HYBRID_SEARCH_ALPHA,
                  cli_overridden_final_top_n_retrieval: int = settings.DEFAULT_RETRIEVAL_FINAL_TOP_N,
                  cli_overridden_max_refinement_iterations: int = settings.DEFAULT_MAX_REFINEMENT_ITERATIONS,
+                 use_llm_relevance_check: bool = settings.USE_LLM_RELEVANCE_CHECK,
+                 reranker_score_threshold: float = settings.RERANKER_SCORE_THRESHOLD,
                  # New parameter for key terms
                  key_terms_definitions: Optional[Dict[str, str]] = None
                 ):
@@ -81,6 +83,8 @@ class ReportGenerationPipeline:
         # self.hybrid_alpha = cli_overridden_hybrid_alpha
         self.final_top_n_retrieval = cli_overridden_final_top_n_retrieval
         self.max_refinement_iterations = cli_overridden_max_refinement_iterations # Used by WorkflowState
+        self.use_llm_relevance_check = use_llm_relevance_check
+        self.reranker_score_threshold = reranker_score_threshold
 
         # Initialize DocumentProcessor with effective chunking parameters
         self.document_processor = DocumentProcessor(
@@ -106,7 +110,11 @@ class ReportGenerationPipeline:
         # after retrieval_service is available.
         self.outline_generator: Optional[OutlineGeneratorAgent] = None
         # ContentRetrieverAgent is initialized in _initialize_retrieval_and_orchestration_components
-        self.chapter_writer = ChapterWriterAgent(llm_service=self.llm_service)
+        self.chapter_writer = ChapterWriterAgent(
+            llm_service=self.llm_service,
+            use_llm_relevance_check=self.use_llm_relevance_check,
+            reranker_score_threshold=self.reranker_score_threshold
+        )
         # EvaluatorAgent now gets its threshold from config.settings
         self.evaluator = EvaluatorAgent(llm_service=self.llm_service)
         self.refiner = RefinerAgent(llm_service=self.llm_service)
@@ -362,7 +370,7 @@ if __name__ == '__main__':
     logger.info("ReportGenerationPipeline (Orchestrator & Indexing Logic) Example Start")
 
     class MockLLMServiceForPipeline(LLMService):
-        def __init__(self): super().__init__(api_url="mock://llm", model_name="mock-llm")
+        def __init__(self): pass
         def chat(self, query, system_prompt, **kwargs):
             # Simulate different responses based on task type indicators in query
             if "主题分析专家" in query: return json.dumps({"generalized_topic_cn": "测试主题", "keywords_cn": ["测试", "流程"]})
@@ -374,7 +382,7 @@ if __name__ == '__main__':
         def get_model(self, model_name): return self
 
     class MockEmbeddingServiceForPipeline(EmbeddingService):
-        def __init__(self): super().__init__(api_url="mock://emb", model_name="mock-emb")
+        def __init__(self): pass
         def create_embeddings(self, texts): return [[0.5]*5 for _ in texts] # Ensure consistent dummy embeddings
         def get_model(self, model_name): return self
 
@@ -396,7 +404,7 @@ if __name__ == '__main__':
             vector_store_path=dummy_vs_dir_pipe,
             index_name="pipeline_test_index",
             force_reindex=True, # Force reindex for consistent test runs
-            max_refinement_iterations=0, # No refinement for this test
+            cli_overridden_max_refinement_iterations=0, # No refinement for this test
             max_workflow_iterations=30, # Generous limit for test
             key_terms_definitions={"CLI_TERM": "Command Line Interface Term, provided at init."} # Test __init__ propagation
         )


### PR DESCRIPTION
This commit introduces a feature flag to control whether the LLM is used to check the relevance of retrieved documents before chapter generation. This is intended to speed up the report generation process when high-precision retrieval is not strictly necessary.

- A new setting `USE_LLM_RELEVANCE_CHECK` is added to `config/settings.py`.
- A command-line argument `--no-llm-relevance-check` is added to `main.py` to disable the check.
- A command-line argument `--reranker-score-threshold` is added to `main.py` to control the relevance threshold when the LLM check is disabled.
- The `ChapterWriterAgent` now accepts `use_llm_relevance_check` and `reranker_score_threshold` parameters and filters documents accordingly.
- The `ReportGenerationPipeline` is updated to pass these parameters to the `ChapterWriterAgent`.